### PR TITLE
Deploy to nsite

### DIFF
--- a/.github/workflows/nsite.yml
+++ b/.github/workflows/nsite.yml
@@ -1,0 +1,30 @@
+name: Deploy nsite
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "yarn"
+
+      - name: Install Dependencies
+        run: yanr install
+
+      - name: Build
+        run: yarn build
+
+      - name: Redirect 404 to Index for SPA
+        run: cp dist/index.html dist/404.html
+
+      - name: Deploy nsite
+        run: npx -y nsite-cli upload dist --purge --privatekey ${{ secrets.NSITE_KEY }}

--- a/.github/workflows/nsite.yml
+++ b/.github/workflows/nsite.yml
@@ -27,4 +27,4 @@ jobs:
         run: cp dist/index.html dist/404.html
 
       - name: Deploy nsite
-        run: npx -y nsite-cli upload dist --purge --privatekey ${{ secrets.NSITE_KEY }}
+        run: npx -y nsite-cli upload dist --verbose --purge --privatekey ${{ secrets.NSITE_KEY }}

--- a/.github/workflows/nsite.yml
+++ b/.github/workflows/nsite.yml
@@ -18,7 +18,7 @@ jobs:
           cache: "yarn"
 
       - name: Install Dependencies
-        run: yanr install
+        run: yarn install
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
This PR setups up a github action to use `nsite-cli` (https://www.npmjs.com/package/nsite-cli) to deploy dtan to "nsite"

## nsite
 
nsite is a static web hosting solution that is built on top of [blossom](https://github.com/hzrd149/blossom) and nostr events

There are two implementation of it so far [nsite-ts](https://github.com/hzrd149/nsite-ts) and [nsite](https://github.com/lez/nsite)

The NIP outlining how it works is in the process of being written up, but here is a short explanation of how it works

1. nsite-cli takes a local directory (in this case `dist`) and uploads all the files to the pubkey's blossom servers (either defined in `k:10063` event or as `--servers` cli flag`
2. nsite-cli creates a `k:34128` event for each file with a `d` and `x` tag and publishes them to the pubkey's relays (NIP-65)
  -  The `d` tag is the absolute path of the file relative to the `dist` folder. so `dist/index.html` would be `/index.html`
   - The `x` tag the sha256 of the file
3. Users visits `https://<npub>.nsite.lol` ([example](https://npub1ajnrp33f2phklcmal8qfs2hza2fm5zvrjfcuggngn872l7d3fd7qugg29h.nsite.lol/)) the "nsite host" server extracts the pubkey from the sub-domain
4. Hosting server looks up the pubkey's relays and blossom servers
5. Hosting server looks for a `k:34128` with a `d` tag matching the requested path
6. Hosting server requests the file (sha256) from the pubkey's blossom servers and responds with the file
7. Profit

## Deploying the app

This PR adds the `.github/workflows/nsite.yml` action that builds the app and deploys it with `nsite-cli`
The action requires that `secrets.NSITE_KEY` be set to a hex or nsec key that the app will be deployed under